### PR TITLE
updated fragment type so that it's compatible with old data

### DIFF
--- a/sbndaq-artdaq-core/Overlays/FragmentType.cc
+++ b/sbndaq-artdaq-core/Overlays/FragmentType.cc
@@ -3,32 +3,33 @@
 #include <algorithm>
 #include <cassert>
 #include <string>
-#include <vector>
+#include <map>
+
 
 namespace {
-  static std::vector<std::string> const
+  static std::map<sbndaq::detail::FragmentType, std::string> const
   names{
-    "MISSED", 
+    {sbndaq::detail::FragmentType::MISSED,           "MISSED"}, 
 
-      //Common
-      "CAENV1730",
-      "SPECTRATIMEVENT",
-      "BERNCRT",
-      "BERNCRTZMQ",
+    //Common
+    {sbndaq::detail::FragmentType::CAENV1730,        "CAENV1730"},
+    {sbndaq::detail::FragmentType::SpectratimeEvent, "SPECTRATIMEVENT"},
+    {sbndaq::detail::FragmentType::BERNCRT,          "BERNCRT"},
+    {sbndaq::detail::FragmentType::BERNCRTZMQ,       "BERNCRTZMQ"},
 
-      //ICARUS
-      "PHYSCRATEDATA",
-      "PHYSCRATESTAT",
+    //ICARUS
+    {sbndaq::detail::FragmentType::PHYSCRATEDATA,    "PHYSCRATEDATA"},
+    {sbndaq::detail::FragmentType::PHYSCRATESTAT,    "PHYSCRATESTAT"},
 
-      //SBND
-      "NEVISTPC",
-      "PTB",
+    //SBND
+    {sbndaq::detail::FragmentType::NevisTPC,         "NEVISTPC"},
+    {sbndaq::detail::FragmentType::PTB,              "PTB"},
 
-      //Simulators
-      "DUMMYGENERATOR",
+    //Simulators
+    {sbndaq::detail::FragmentType::DummyGenerator,   "DUMMYGENERATOR"},
 
-      "UNKNOWN"
-      };
+    {sbndaq::detail::FragmentType::INVALID,          "UNKNOWN"}
+  };
 }
 
 sbndaq::FragmentType
@@ -38,30 +39,29 @@ sbndaq::toFragmentType(std::string t_string)
                  t_string.end(),
                  t_string.begin(),
                  toupper);
-  auto it = std::find(names.begin(), names.end(), t_string);
-  return (it == names.end()) ?
-    FragmentType::INVALID :
-    static_cast<FragmentType>(artdaq::Fragment::FirstUserFragmentType +
-                              (it - names.begin()));
+  for(auto it = names.begin(); it != names.end(); ++it)
+    if(t_string == it->second)
+      return static_cast<FragmentType>(it->first);
+  return FragmentType::INVALID;
 }
 
 std::string
 sbndaq::fragmentTypeToString(FragmentType val)
 {
   if (val < FragmentType::INVALID) {
-    return names[val - FragmentType::MISSED];
+    return names.at(val);
   }
   else {
-    return "INVALID/UNKNOWN";
+    return "INVALID/UNKNOWN"; //AA: why is it INVALID/UNKNOWN rather than UNKNOWN, as defined in the list above?
   }
 }
 
 std::map< artdaq::Fragment::type_t, std::string > sbndaq::makeFragmentTypeMap()
 {
-	auto output = artdaq::Fragment::MakeSystemTypeMap();
-	for (auto name : names)
-	{
-		output[toFragmentType(name)] = name;
-	}
-	return output;
+      auto output = artdaq::Fragment::MakeSystemTypeMap();
+      for (auto name : names)
+      {
+               output[name.first] = name.second;
+      }
+      return output;
 }

--- a/sbndaq-artdaq-core/Overlays/FragmentType.hh
+++ b/sbndaq-artdaq-core/Overlays/FragmentType.hh
@@ -4,28 +4,33 @@
 
 namespace sbndaq {
 
+/*
+   Note, if you add new frament types, the use a new enum number for them, so that the old numbering scheme is not changed
+
+   */
+
   namespace detail {
-    enum FragmentType : artdaq::Fragment::type_t
-    { MISSED = artdaq::Fragment::FirstUserFragmentType,
-	//COMMON
-	CAENV1730,
-	SpectratimeEvent,
-	BERNCRT,
-	BERNCRTZMQ,
+    enum FragmentType : artdaq::Fragment::type_t {
+      MISSED           = artdaq::Fragment::FirstUserFragmentType,
+      //COMMON
+      CAENV1730        = artdaq::Fragment::FirstUserFragmentType + 1,
+      SpectratimeEvent = artdaq::Fragment::FirstUserFragmentType + 2,
+      BERNCRT          = artdaq::Fragment::FirstUserFragmentType + 9,
+      BERNCRTZMQ       = artdaq::Fragment::FirstUserFragmentType + 3,
 
-	//ICARUS
-	PHYSCRATEDATA,
-	PHYSCRATESTAT,
+      //ICARUS
+      PHYSCRATEDATA    = artdaq::Fragment::FirstUserFragmentType + 4,
+      PHYSCRATESTAT    = artdaq::Fragment::FirstUserFragmentType + 5,
 
-	//SBND
-	NevisTPC,
-	PTB,
+      //SBND
+      NevisTPC         = artdaq::Fragment::FirstUserFragmentType + 6,
+      PTB              = artdaq::Fragment::FirstUserFragmentType + 7,
 
-        //Simulators
-        DummyGenerator,
+      //Simulators
+      DummyGenerator   = artdaq::Fragment::FirstUserFragmentType + 8,
 
-        INVALID // Should always be last.
-        };
+      INVALID          = artdaq::Fragment::FirstUserFragmentType + 10 // Should always be last.
+    };
 
     // Safety check.
     static_assert(artdaq::Fragment::isUserFragmentType(FragmentType::INVALID - 1),


### PR DESCRIPTION
Modified FragmentType so that the enums are the same as in the previous releases, and new types: BernCRT and DummyGenerator are added at the end of the list.
Test run: 2137.