### PR TITLE
Feature/jzettle read trigger data icarus

### DIFF
--- a/sbndaq-artdaq-core/Overlays/CMakeLists.txt
+++ b/sbndaq-artdaq-core/Overlays/CMakeLists.txt
@@ -12,9 +12,9 @@ install_source()
 
 add_subdirectory(Common)
 
-IF(ICARUS_BUILD)
+#IF(ICARUS_BUILD)
 add_subdirectory(ICARUS)
-ENDIF()
+#ENDIF()
 
 # Wes will want to fix the following
 #IF(SBND_BUILD)

--- a/sbndaq-artdaq-core/Overlays/FragmentType.cc
+++ b/sbndaq-artdaq-core/Overlays/FragmentType.cc
@@ -4,27 +4,34 @@
 #include <cassert>
 #include <string>
 #include <vector>
+#include <map>
 
 namespace {
-  static std::vector<std::string> const
+  static std::map<sbndaq::detail::FragmentType,std::string> const
   names{
-    "MISSED", 
+    {sbndaq::detail::FragmentType::MISSED, "MISSED"}, 
 
       //Common
-      "CAENV1730",
-      "SPECTRATIMEVENT",
-      "BERNCRTZMQ",
+    {sbndaq::detail::FragmentType::CAENV1730, "CAENV1730"},
+    {sbndaq::detail::FragmentType::SpectratimeEvent, "SPECTRATIMEVENT"},
+    {sbndaq::detail::FragmentType::BERNCRT, "BERNCRT"},
+    {sbndaq::detail::FragmentType::BERNCRTZMQ,  "BERNCRTZMQ"},
 
-      //ICARUS
-      "PHYSCRATEDATA",
-      "PHYSCRATESTAT",
+    //ICARUS
+    {sbndaq::detail::FragmentType::PHYSCRATEDATA,  "PHYSCRATEDATA"},
+    {sbndaq::detail::FragmentType::PHYSCRATESTAT, "PHYSCRATESTAT"},
+    {sbndaq::detail::FragmentType::ICARUSTriggerUDP,  "ICARUSTriggerUDP"},
+    {sbndaq::detail::FragmentType::ICARUSPMTGate, "ICARUSPMTGate"},
 
-      //SBND
-      "NEVISTPC",
-      "PTB",
-
-      "UNKNOWN"
-      };
+    //SBND
+    {sbndaq::detail::FragmentType::NevisTPC, "NEVISTPC"},
+    {sbndaq::detail::FragmentType::PTB,  "PTB"},
+    
+      //Simulators
+    {sbndaq::detail::FragmentType::DummyGenerator, "DUMMYGENERATOR"},  
+    
+    {sbndaq::detail::FragmentType::INVALID,  "UNKNOWN"}
+  };
 }
 
 sbndaq::FragmentType
@@ -34,18 +41,25 @@ sbndaq::toFragmentType(std::string t_string)
                  t_string.end(),
                  t_string.begin(),
                  toupper);
+  /*
   auto it = std::find(names.begin(), names.end(), t_string);
   return (it == names.end()) ?
     FragmentType::INVALID :
     static_cast<FragmentType>(artdaq::Fragment::FirstUserFragmentType +
                               (it - names.begin()));
+  */
+  for(auto it = names.begin(); it != names.end(); ++it)
+    if(t_string == it->second)
+      return static_cast<FragmentType>(it->first);
+  return FragmentType::INVALID;
 }
 
 std::string
 sbndaq::fragmentTypeToString(FragmentType val)
 {
   if (val < FragmentType::INVALID) {
-    return names[val - FragmentType::MISSED];
+    //return names[val - FragmentType::MISSED];
+    return names.at(val);
   }
   else {
     return "INVALID/UNKNOWN";
@@ -54,10 +68,18 @@ sbndaq::fragmentTypeToString(FragmentType val)
 
 std::map< artdaq::Fragment::type_t, std::string > sbndaq::makeFragmentTypeMap()
 {
+  /*
 	auto output = artdaq::Fragment::MakeSystemTypeMap();
 	for (auto name : names)
 	{
 		output[toFragmentType(name)] = name;
 	}
 	return output;
+  */
+  auto output = artdaq::Fragment::MakeSystemTypeMap();
+  for (auto name : names)
+  {
+    output[name.first] = name.second;
+  }
+  return output;
 }

--- a/sbndaq-artdaq-core/Overlays/FragmentType.hh
+++ b/sbndaq-artdaq-core/Overlays/FragmentType.hh
@@ -8,20 +8,25 @@ namespace sbndaq {
     enum FragmentType : artdaq::Fragment::type_t
     { MISSED = artdaq::Fragment::FirstUserFragmentType,
 	//COMMON
-	CAENV1730,
-	SpectratimeEvent,
-	BERNCRTZMQ,
+	CAENV1730 = artdaq::Fragment::FirstUserFragmentType + 1,
+	SpectratimeEvent = artdaq::Fragment::FirstUserFragmentType + 2,
+	BERNCRT = artdaq::Fragment::FirstUserFragmentType + 9,
+	BERNCRTZMQ = artdaq::Fragment::FirstUserFragmentType + 3,
 
 	//ICARUS
-	PHYSCRATEDATA,
-	PHYSCRATESTAT,
-	ICARUSTriggerUDP,
+	PHYSCRATEDATA = artdaq::Fragment::FirstUserFragmentType + 4,
+	PHYSCRATESTAT = artdaq::Fragment::FirstUserFragmentType + 5,
+	ICARUSTriggerUDP = artdaq::Fragment::FirstUserFragmentType + 10,
+	ICARUSPMTGate = artdaq::Fragment::FirstUserFragmentType + 11,
 
 	//SBND
-	NevisTPC,
-	PTB,
+	NevisTPC = artdaq::Fragment::FirstUserFragmentType + 6,
+	PTB = artdaq::Fragment::FirstUserFragmentType + 7,
+	
+	//Simulators
+	DummyGenerator = artdaq::Fragment::FirstUserFragmentType + 8,
 
-        INVALID // Should always be last.
+        INVALID = artdaq::Fragment::FirstUserFragmentType + 12 // Should always be last.
         };
 
     // Safety check.

--- a/sbndaq-artdaq-core/Overlays/FragmentType.hh
+++ b/sbndaq-artdaq-core/Overlays/FragmentType.hh
@@ -15,6 +15,7 @@ namespace sbndaq {
 	//ICARUS
 	PHYSCRATEDATA,
 	PHYSCRATESTAT,
+	ICARUSTriggerUDP,
 
 	//SBND
 	NevisTPC,

--- a/sbndaq-artdaq-core/Overlays/ICARUS/CMakeLists.txt
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/CMakeLists.txt
@@ -2,6 +2,8 @@ cet_make_library( LIBRARY_NAME sbndaq-artdaq-core_Overlays_ICARUS
 		  SOURCE 
 		  PhysCrateFragment.cc
 		  PhysCrateStatFragment.cc
+		  ICARUSTriggerUDPFragment.cc
+		  ICARUSPMTGateFragment.cc		  
 		  LIBRARIES
 		  ${ARTDAQ_DAQDATA}
 			${ARTDAQ-CORE_UTILITIES}

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSPMTGateFragment.cc
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSPMTGateFragment.cc
@@ -1,0 +1,6 @@
+#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSPMTGateFragment.hh"
+#include "cetlib_except/exception.h"
+
+bool icarus::ICARUSPMTGateFragment::Verify() const {
+  return true;
+}

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSPMTGateFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSPMTGateFragment.hh
@@ -1,0 +1,49 @@
+#ifndef sbndaq_artdaq_core_Overlays_ICARUS_ICARUSPMTGateFragment_hh
+#define sbndaq_artdaq_core_Overlays_ICARUS_ICARUSPMTGateFragment_hh
+
+#include "artdaq-core/Data/Fragment.hh"
+#include "cetlib_except/exception.h"
+
+#include <iostream>
+
+namespace icarus {
+
+  class ICARUSPMTGateFragment;
+
+  struct ICARUSPMTGateFragmentMetadata;
+
+}
+
+struct icarus::ICARUSPMTGateFragmentMetadata
+{
+  std::vector<int> num;
+
+  ICARUSPMTGateFragmentMetadata() {}
+  ICARUSPMTGateFragmentMetadata(std::vector<int> n) : num(n) {}
+
+  std::vector<int> getNum() const
+  { return num; }
+};
+
+class icarus::ICARUSPMTGateFragment{
+
+public:
+
+  ICARUSPMTGateFragment(artdaq::Fragment const &f) : fFragment(f) {}
+  ICARUSPMTGateFragmentMetadata const * Metadata() const
+  { return fFragment.metadata<ICARUSPMTGateFragmentMetadata>(); }
+
+  size_t DataPayloadSize() const
+  { return fFragment.dataSizeBytes(); }
+
+  std::vector<int> getNum() const
+  { return Metadata()->getNum(); }
+
+  bool Verify() const;
+
+private:
+  artdaq::Fragment fFragment;
+
+};
+
+#endif /* sbndaq_datatypes_Overlays_ICARUSPMTGateFragment_hh */

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.cc
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.cc
@@ -1,0 +1,6 @@
+#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh"
+#include "cetlib_except/exception.h"
+
+bool sbndaq::ICARUSTriggerUDPFragment::Verify() const {
+  return true;
+}

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.cc
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.cc
@@ -1,6 +1,25 @@
 #include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh"
 #include "cetlib_except/exception.h"
 
-bool sbndaq::ICARUSTriggerUDPFragment::Verify() const {
+
+
+std::ostream & icarus::operator << (std::ostream & os, ICARUSTriggerUDPFragment const & f) {
+  os << "ICARUSTriggerUDPFragment: " << *(f.Metadata());
+  os << std::endl;
+  return os;
+}
+
+std::ostream & icarus::operator << (std::ostream & os, ICARUSTriggerUDPFragmentMetadata const & m) {
+  os << "\n\t Name: " << m.getName();
+  os << "\n\t Event Number: " << m.getEventNo();
+  os << "\n\t Seconds: " << m.getSeconds();
+  os << "\n\t Nanoseconds: " << m.getNanoSeconds();
+  os << std::endl;
+  return os;
+}
+
+
+
+bool icarus::ICARUSTriggerUDPFragment::Verify() const {
   return true;
 }

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
@@ -4,25 +4,27 @@
 #include "artdaq-core/Data/Fragment.hh"
 #include "cetlib_except/exception.h"
 
-namespace sbndaq {
+#include <iostream>
+
+namespace icarus {
 
   class ICARUSTriggerUDPFragment;
+  std::ostream & operator << (std::ostream &, ICARUSTriggerUDPFragment const &);
 
-  struct ICARUSTriggerUDPFragmentMetadata;
-
+  //struct ICARUSTriggerUDPFragmentMetadata;
+  class ICARUSTriggerUDPFragmentMetadata;
+  std::ostream & operator << (std::ostream &, ICARUSTriggerUDPFragmentMetadata const &);
 }
 
-struct sbndaq::ICARUSTriggerUDPFragmentMetadata
+//struct icarus::ICARUSTriggerUDPFragmentMetadata
+class icarus::ICARUSTriggerUDPFragmentMetadata
 {
-  std::string name;
-  int event_no;
-  int seconds;
-  long nanoseconds;
-  
-  ICARUSTriggerUDPFragmentMetadata() {}
-  ICARUSTriggerUDPFragmentMetadata(std::string n, int ev, int sec, long nsec) : name(n), event_no(ev), seconds(sec), nanoseconds(nsec) {}
 
-  std::string getName() const
+public:  
+  ICARUSTriggerUDPFragmentMetadata() {}
+  ICARUSTriggerUDPFragmentMetadata(int n, int ev, int sec, long nsec) : name(n), event_no(ev), seconds(sec), nanoseconds(nsec) {}
+
+  int getName() const
   { return name; }
   
   int getEventNo() const
@@ -33,15 +35,22 @@ struct sbndaq::ICARUSTriggerUDPFragmentMetadata
 
   long getNanoSeconds() const
   { return nanoseconds; }
+
+private:
+  int name;
+  int event_no;
+  int seconds;
+  long nanoseconds;
+
 };
 
-class sbndaq::ICARUSTriggerUDPFragment{
+class icarus::ICARUSTriggerUDPFragment{
 
 public:
   
   ICARUSTriggerUDPFragment(artdaq::Fragment const &f) : fFragment(f) {}
   ICARUSTriggerUDPFragmentMetadata const * Metadata() const
-  { return fFragment.metadata<sbndaq::ICARUSTriggerUDPFragmentMetadata>(); }
+  { return fFragment.metadata<ICARUSTriggerUDPFragmentMetadata>(); }
   
   size_t DataPayloadSize() const
   { return fFragment.dataSizeBytes(); }
@@ -50,7 +59,7 @@ public:
   { return Metadata()->ExpectedDataSize(); }
   */
 
-  std::string getName() const
+  int getName() const
   { return Metadata()->getName(); }
   
   int getEventNo() const

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
@@ -1,0 +1,72 @@
+#ifndef sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerUDPFragment_hh
+#define sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerUDPFragment_hh
+
+#include "artdaq-core/Data/Fragment.hh"
+#include "cetlib_except/exception.h"
+
+namespace sbndaq {
+
+  class ICARUSTriggerUDPFragment;
+
+  struct ICARUSTriggerUDPFragmentMetadata;
+
+}
+
+struct sbndaq::ICARUSTriggerUDPFragmentMetadata
+{
+  std::string name;
+  int event_no;
+  int seconds;
+  long nanoseconds;
+  
+  ICARUSTriggerUDPFragmentMetadata() {}
+  ICARUSTriggerUDPFragmentMetadata(std::string n, int ev, int sec, long nsec) : name(n), event_no(ev), seconds(sec), nanoseconds(nsec) {}
+
+  std::string getName() const
+  { return name; }
+  
+  int getEventNo() const
+  { return event_no; }
+
+  int getSeconds() const
+  { return seconds; }
+
+  long getNanoSeconds() const
+  { return nanoseconds; }
+};
+
+class sbndaq::ICARUSTriggerUDPFragment{
+
+public:
+  
+  ICARUSTriggerUDPFragment(artdaq::Fragment const &f) : fFragment(f) {}
+  ICARUSTriggerUDPFragmentMetadata const * Metadata() const
+  { return fFragment.metadata<sbndaq::ICARUSTriggerUDPFragmentMetadata>(); }
+  
+  size_t DataPayloadSize() const
+  { return fFragment.dataSizeBytes(); }
+  /*
+  size_t ExpectedDataSize() const
+  { return Metadata()->ExpectedDataSize(); }
+  */
+
+  std::string getName() const
+  { return Metadata()->getName(); }
+  
+  int getEventNo() const
+  { return Metadata()->getEventNo(); }
+  
+  int getSeconds() const
+  { return Metadata()->getSeconds(); }
+  
+  long getNanoSeconds() const
+  { return Metadata()->getNanoSeconds(); }
+  
+  bool Verify() const;
+  
+private:
+  artdaq::Fragment fFragment;
+
+};
+
+#endif /* sbndaq_datatypes_Overlays_ICARUSTriggerUDPFragment_hh */


### PR DESCRIPTION
Pull request to merge trigger DAQ which creates and analyzes fragment from the ICARUS Trigger with the full DAQ. Tested using fake trigger script and SPEXI trigger board used in ICARUS. Can create fragments and analyze data which prints out information received from the trigger board from runs using the trigger board. 