### PR TITLE
no warning on nested anon types

### DIFF
--- a/sbndaq-artdaq-core/Overlays/CMakeLists.txt
+++ b/sbndaq-artdaq-core/Overlays/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_definitions(-Wno-nested-anon-types)
 cet_make_library( LIBRARY_NAME sbndaq-artdaq-core_Overlays
 		  SOURCE 
 		  FragmentType.cc


### PR DESCRIPTION
fixes a compilation issue with c7 for the offline. Think it doesn't hurt to add to online too.