### PR TITLE
Patch NuMI Gate Type for ICARUS trigger fragment

### DIFF
--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
@@ -205,7 +205,7 @@ public:
   { return getGateType()==1; }
 
   bool isNuMI() const
-  { return getGateType()==3; }
+  { return getGateType()==2; }
 
   int getGateType() const
   { return info.gate_type; }

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -1,6 +1,6 @@
 # The parent line must be the first non-comment line in the file
 # This line defines the product name and version
-parent sbndaq_artdaq_core       v0_07_06_of0
+parent sbndaq_artdaq_core       v0_07_06_01_of0
 
 # These optional lines define the installed directories where
 # headers, libraries, and executables will be found


### PR DESCRIPTION
gate type was set incorrectly for NuMI in ICARUS trigger fragment overlay class. Needs to be updated.

I've already bumped to version v0_07_06_01_of0, to indicate this is a patch release.