### PR TITLE
Fixed rounding error in trigger time

### DIFF
--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
@@ -51,7 +51,7 @@ struct icarus::ICARUSTriggerInfo
     if(wr_seconds >= 1483228800)
       correction = 37;
     uint64_t const corrected_ts
-      { (wr_seconds-correction)*1'000'000'000 + wr_nanoseconds };
+      { (wr_seconds-correction)*1'000'000'000ULL + wr_nanoseconds };
     return corrected_ts;
   }
   

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
@@ -50,7 +50,9 @@ struct icarus::ICARUSTriggerInfo
     int correction = 0;
     if(wr_seconds >= 1483228800)
       correction = 37;
-    return (wr_seconds-correction)*1e9 + wr_nanoseconds;
+    uint64_t const corrected_ts
+      { (wr_seconds-correction)*1'000'000'000 + wr_nanoseconds };
+    return corrected_ts;
   }
   
 };


### PR DESCRIPTION
The code to apply the time scale correction to the White Rabbit time of the trigger implicitly converted the time to `double`, with consequent loss of precision. The proposed code avoids the conversion (using `1'000'000'000` instead of `1e9`) and also asks the compiler to guarantee that there is no loss by using a braced initialisation that does not allow narrowing.