### PR TITLE
Remove art exceptions include

### DIFF
--- a/sbndaq-artdaq-core/Overlays/Common/BernCRTTranslator.cc
+++ b/sbndaq-artdaq-core/Overlays/Common/BernCRTTranslator.cc
@@ -1,5 +1,3 @@
-#include "canvas/Utilities/Exception.h"
-
 #include "BernCRTZMQFragment.hh"
 #include "BernCRTFragment.hh"
 #include "BernCRTFragmentV2.hh"


### PR DESCRIPTION
The offline branch does not currently compile (as apparent in this weekend's CI builds). The following error message is given:

```
764: /scratch/workspace/sbnd_ci/label_exp/SLF7/label_exp2/swarm/SBND/srcs/sbndaq_artdaq_core/sbndaq-artdaq-core/Overlays/Common/BernCRTTranslator.cc:1:10: fatal error: 'canvas/Utilities/Exception.h' file not found
765: #include "canvas/Utilities/Exception.h"
766:          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I've taken a quick look at this and it appears that this file was imported from `icaruscode` where it could import art libraries but here I don't believe it will have the right dependencies even if we added the relevant library in `CMakeLists.txt`. The file does not appear to actually need the exceptions header though and compiles fine without it.

I've tested this branch on the CI and it successfully builds in both [e20](https://dbweb8.fnal.gov:8443/LarCI/app/ns:sbnd/build_detail/phase_details?build_id=sbnd_ci/7340&platform=Linux%203.10.0-1160.31.1.el7.x86_64&phase=build&buildtype=slf7%20e20:prof) and [c7](https://dbweb8.fnal.gov:8443/LarCI/app/ns:sbnd/build_detail/phase_details?build_id=sbnd_ci/7341&platform=Linux%203.10.0-1160.31.1.el7.x86_64&phase=build&buildtype=slf7%20c7:prof).