### PR TITLE
Merged the two definitions of icarus::ICARUSTriggerInfo

### DIFF
--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerInfo.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerInfo.hh
@@ -1,0 +1,55 @@
+#ifndef sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerInfo_hh
+#define sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerInfo_hh
+
+#include <string>
+#include <cstdint>
+
+
+namespace icarus { struct ICARUSTriggerInfo; }
+
+struct icarus::ICARUSTriggerInfo
+{
+  int version                =  0;
+  std::string name;
+  long event_no              = -1;
+  long seconds               = -2;
+  long nanoseconds           = -3;
+  std::string wr_name;
+  long wr_event_no           = -1;
+  long wr_seconds            = -2;
+  long wr_nanoseconds        = -3;
+  int enable_type            = -1;
+  long enable_seconds        =  0;
+  long enable_nanoseconds    =  0;
+  long gate_id               = -4;
+  long gate_id_BNB           = -4;
+  long gate_id_NuMI          = -4;
+  long gate_id_BNBOff        = -4;
+  long gate_id_NuMIOff       = -4;
+  int gate_type              =  0;
+  long beam_seconds          =  0;
+  long beam_nanoseconds      =  0;
+  int trigger_type           =  0;
+  int trigger_source         =  0;
+  std::string cryo1_e_conn_0;
+  std::string cryo1_e_conn_2;
+  std::string cryo2_w_conn_0;
+  std::string cryo2_w_conn_2;
+  long cryo1_east_counts     = -1;
+  long cryo2_west_counts     = -1;
+
+  uint64_t getNanoseconds_since_UTC_epoch() const {
+    if(wr_seconds == -2 || wr_nanoseconds == -3)
+      return 0;
+    int correction = 0;
+    if(wr_seconds >= 1483228800)
+      correction = 37;
+    uint64_t const corrected_ts
+      { (wr_seconds-correction)*1000000000ULL + wr_nanoseconds };
+    return corrected_ts;
+  }
+  
+}; // icarus::ICARUSTriggerInfo
+
+
+#endif /* sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerInfo_hh */

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
@@ -1,16 +1,16 @@
 #ifndef sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerUDPFragment_hh
 #define sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerUDPFragment_hh
 
+#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerInfo.hh"
 #include "artdaq-core/Data/Fragment.hh"
 #include "cetlib_except/exception.h"
 
-#include <iostream>
+#include <ostream>
 #include <chrono>
 
 
 namespace icarus {
 
-  struct ICARUSTriggerInfo;
   ICARUSTriggerInfo parse_ICARUSTriggerString(const char*);
   class ICARUSTriggerUDPFragment;
   std::ostream & operator << (std::ostream &, ICARUSTriggerUDPFragment const &);
@@ -20,48 +20,8 @@ namespace icarus {
   //std::ostream & operator << (std::ostream &, ICARUSTriggerUDPFragmentMetadata const &);
 }
 
-struct icarus::ICARUSTriggerInfo
-{
-  std::string name;
-  long event_no;
-  long seconds;
-  long nanoseconds;
-  std::string wr_name;
-  long wr_event_no;
-  long wr_seconds;
-  long wr_nanoseconds;
-  long gate_id;
-  int gate_type;
-  //long beam_seconds;
-  //long beam_nanoseconds;
-  ICARUSTriggerInfo() {
-    name = ""; 
-    event_no = -1; 
-    seconds = -2; 
-    nanoseconds = -3; 
-    wr_name = ""; 
-    wr_event_no = -1; 
-    wr_seconds = -2; 
-    wr_nanoseconds = -3;
-    gate_id = -4;
-    gate_type = 0;
-    //beam_seconds = 0;
-    //beam_nanoseconds = 0;
-  }
-  uint64_t getNanoseconds_since_UTC_epoch() {
-    if(wr_seconds == -2 || wr_nanoseconds == -3)
-      return 0;
-    int correction = 0;
-    if(wr_seconds >= 1483228800)
-      correction = 37;
-    uint64_t const corrected_ts
-    { (wr_seconds-correction)*1000000000ULL + wr_nanoseconds };
-    return corrected_ts;
-  }
-  
-};
 
-icarus::ICARUSTriggerInfo icarus::parse_ICARUSTriggerString(const char* buffer)
+inline icarus::ICARUSTriggerInfo icarus::parse_ICARUSTriggerString(const char* buffer)
 {
   std::string data_input = buffer;
   size_t pos = 0;

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerV2Fragment.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerV2Fragment.hh
@@ -1,10 +1,11 @@
 #ifndef sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerV2Fragment_hh
 #define sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerV2Fragment_hh
 
+#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerInfo.hh"
 #include "artdaq-core/Data/Fragment.hh"
 #include "cetlib_except/exception.h"
 
-#include <iostream>
+#include <ostream>
 #include <chrono>
 #include <string>
 #include <map>
@@ -12,7 +13,6 @@
 
 namespace icarus {
 
-  struct ICARUSTriggerInfo;
   ICARUSTriggerInfo parse_ICARUSTriggerV2String(const char*);
   class ICARUSTriggerV2Fragment;
   std::ostream & operator << (std::ostream &, ICARUSTriggerV2Fragment const &);
@@ -22,82 +22,8 @@ namespace icarus {
   //std::ostream & operator << (std::ostream &, ICARUSTriggerV2FragmentMetadata const &);
 }
 
-struct icarus::ICARUSTriggerInfo
-{
-  int version;
-  std::string name;
-  long event_no;
-  long seconds;
-  long nanoseconds;
-  std::string wr_name;
-  long wr_event_no;
-  long wr_seconds;
-  long wr_nanoseconds;
-  int enable_type;
-  long enable_seconds;
-  long enable_nanoseconds;
-  long gate_id;
-  long gate_id_BNB;
-  long gate_id_NuMI;
-  long gate_id_BNBOff;
-  long gate_id_NuMIOff;
-  int gate_type;
-  long beam_seconds;
-  long beam_nanoseconds;
-  int trigger_type;
-  int trigger_source;
-  std::string cryo1_e_conn_0;
-  std::string cryo1_e_conn_2;
-  std::string cryo2_w_conn_0;
-  std::string cryo2_w_conn_2;
-  long cryo1_east_counts;
-  long cryo2_west_counts;
 
-  ICARUSTriggerInfo() {
-    version = 0;
-    name = ""; 
-    event_no = -1; 
-    seconds = -2; 
-    nanoseconds = -3; 
-    wr_name = ""; 
-    wr_event_no = -1; 
-    wr_seconds = -2; 
-    wr_nanoseconds = -3;
-    enable_type = -1;
-    enable_seconds = 0;
-    enable_nanoseconds = 0;
-    gate_id = -4;
-    gate_type = 0;
-    gate_id_BNB = -4;
-    gate_id_NuMI = -4;
-    gate_id_BNBOff = -4;
-    gate_id_NuMIOff = -4;
-    beam_seconds = 0;
-    beam_nanoseconds = 0;
-    trigger_type = 0;
-    trigger_source = 0;
-    cryo1_e_conn_0 = "";
-    cryo1_e_conn_2 = "";
-    cryo2_w_conn_0 = "";
-    cryo2_w_conn_2 = "";
-    cryo1_east_counts = -1;
-    cryo2_west_counts = -1;
-    
-  }
-  uint64_t getNanoseconds_since_UTC_epoch() {
-    if(wr_seconds == -2 || wr_nanoseconds == -3)
-      return 0;
-    int correction = 0;
-    if(wr_seconds >= 1483228800)
-      correction = 37;
-    uint64_t const corrected_ts
-      { (wr_seconds-correction)*1000000000ULL + wr_nanoseconds };
-    return corrected_ts;
-  }
-  
-};
-
-icarus::ICARUSTriggerInfo icarus::parse_ICARUSTriggerV2String(const char* buffer)
+inline icarus::ICARUSTriggerInfo icarus::parse_ICARUSTriggerV2String(const char* buffer)
 {
   std::string data_input = buffer;
   size_t pos = 0;


### PR DESCRIPTION
### Description

With the advent of the new version of ICARUS trigger, code was branched to have both an old and a new version (labelled somewhere `UDP` and `V2` respectively). An exception was that the data structure `icarus::ICARUSTriggerInfo` forked and lived with two different incarnations at the same time.
Their presence together caused subtle bugs at (dynamic) link time; one observed effect was for the constructor of one being called instead of the constructor of the other, and since the layout of the two classes is slightly shifted, strings were constructed wrongly, yielding sometimes a segmentation fault (most of the time not though).

This patch merges the two structures into one (the one from `V2`) with the understanding that not all trigger versions will fill all the fields. The default value of `version` data member, `0`, points to the format of the old trigger, and provides a way to check the available information (in fact, that was the purpose of its introduction in the new trigger, which despite being labelled `V2` is numbered version `1`).
The definition of the class, still fully in header, is moved to its own file which is included by both trigger version implementations.
Given that the name of the class stays the same, this should be a non-breaking change. And since the new trigger info class `icarus::ICARUSTriggerInfo` is a superset of the old one, that extension is also not a breaking change (the layout of the class _is_ different, so it's binary-incompatible).

In addition, a few C++ changes are introduced:
* the merged class has the default constructor implicitly defined, and the data member default values assigned in the class definition.
* the `iostream` header has been replaced by `ostream` (that is what was needed).
* the definitions of the functions in the headers are now marked `inline`.

### Testing details

This commit was tested only in the ICARUS off-line code (trigger decoding).
**Online testing is still required.**
