### PR TITLE
Merge definitions of icarus::icarusTriggerInfo

### DIFF
--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerInfo.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerInfo.hh
@@ -1,0 +1,55 @@
+#ifndef sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerInfo_hh
+#define sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerInfo_hh
+
+#include <string>
+#include <cstdint>
+
+
+namespace icarus { struct ICARUSTriggerInfo; }
+
+struct icarus::ICARUSTriggerInfo
+{
+  int version                =  0;
+  std::string name;
+  long event_no              = -1;
+  long seconds               = -2;
+  long nanoseconds           = -3;
+  std::string wr_name;
+  long wr_event_no           = -1;
+  long wr_seconds            = -2;
+  long wr_nanoseconds        = -3;
+  int enable_type            = -1;
+  long enable_seconds        =  0;
+  long enable_nanoseconds    =  0;
+  long gate_id               = -4;
+  long gate_id_BNB           = -4;
+  long gate_id_NuMI          = -4;
+  long gate_id_BNBOff        = -4;
+  long gate_id_NuMIOff       = -4;
+  int gate_type              =  0;
+  long beam_seconds          =  0;
+  long beam_nanoseconds      =  0;
+  int trigger_type           =  0;
+  int trigger_source         =  0;
+  std::string cryo1_e_conn_0;
+  std::string cryo1_e_conn_2;
+  std::string cryo2_w_conn_0;
+  std::string cryo2_w_conn_2;
+  long cryo1_east_counts     = -1;
+  long cryo2_west_counts     = -1;
+
+  uint64_t getNanoseconds_since_UTC_epoch() const {
+    if(wr_seconds == -2 || wr_nanoseconds == -3)
+      return 0;
+    int correction = 0;
+    if(wr_seconds >= 1483228800)
+      correction = 37;
+     uint64_t const corrected_ts
+     { (wr_seconds-correction)*1000000000ULL + wr_nanoseconds };
+     return corrected_ts;
+  }
+
+}; // icarus::ICARUSTriggerInfo
+
+
+#endif /* sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerInfo_hh */

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh
@@ -1,16 +1,17 @@
 #ifndef sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerUDPFragment_hh
 #define sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerUDPFragment_hh
 
+#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerInfo.hh"
 #include "artdaq-core/Data/Fragment.hh"
 #include "cetlib_except/exception.h"
 
-#include <iostream>
+#include <ostream>
 #include <chrono>
 
 
 namespace icarus {
 
-  struct ICARUSTriggerInfo;
+  
   ICARUSTriggerInfo parse_ICARUSTriggerString(const char*);
   class ICARUSTriggerUDPFragment;
   std::ostream & operator << (std::ostream &, ICARUSTriggerUDPFragment const &);
@@ -20,48 +21,7 @@ namespace icarus {
   //std::ostream & operator << (std::ostream &, ICARUSTriggerUDPFragmentMetadata const &);
 }
 
-struct icarus::ICARUSTriggerInfo
-{
-  std::string name;
-  long event_no;
-  long seconds;
-  long nanoseconds;
-  std::string wr_name;
-  long wr_event_no;
-  long wr_seconds;
-  long wr_nanoseconds;
-  long gate_id;
-  int gate_type;
-  //long beam_seconds;
-  //long beam_nanoseconds;
-  ICARUSTriggerInfo() {
-    name = ""; 
-    event_no = -1; 
-    seconds = -2; 
-    nanoseconds = -3; 
-    wr_name = ""; 
-    wr_event_no = -1; 
-    wr_seconds = -2; 
-    wr_nanoseconds = -3;
-    gate_id = -4;
-    gate_type = 0;
-    //beam_seconds = 0;
-    //beam_nanoseconds = 0;
-  }
-  uint64_t getNanoseconds_since_UTC_epoch() {
-    if(wr_seconds == -2 || wr_nanoseconds == -3)
-      return 0;
-    int correction = 0;
-    if(wr_seconds >= 1483228800)
-      correction = 37;
-    uint64_t const corrected_ts
-    { (wr_seconds-correction)*1000000000ULL + wr_nanoseconds };
-    return corrected_ts;
-  }
-  
-};
-
-icarus::ICARUSTriggerInfo icarus::parse_ICARUSTriggerString(const char* buffer)
+inline icarus::ICARUSTriggerInfo icarus::parse_ICARUSTriggerString(const char* buffer)
 {
   std::string data_input = buffer;
   size_t pos = 0;

--- a/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerV2Fragment.hh
+++ b/sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerV2Fragment.hh
@@ -1,11 +1,12 @@
 #ifndef sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerV2Fragment_hh
 #define sbndaq_artdaq_core_Overlays_ICARUS_ICARUSTriggerV2Fragment_hh
 
+#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerInfo.hh"
 #include "artdaq-core/Data/Fragment.hh"
 #include "sbndaq-artdaq-core/Trace/trace_defines.h"
 #include "cetlib_except/exception.h"
 
-#include <iostream>
+#include <ostream>
 #include <chrono>
 #include <string>
 #include <map>
@@ -13,7 +14,6 @@
 
 namespace icarus {
 
-  struct ICARUSTriggerInfo;
   ICARUSTriggerInfo parse_ICARUSTriggerV2String(const char*);
   class ICARUSTriggerV2Fragment;
   std::ostream & operator << (std::ostream &, ICARUSTriggerV2Fragment const &);
@@ -23,82 +23,7 @@ namespace icarus {
   //std::ostream & operator << (std::ostream &, ICARUSTriggerV2FragmentMetadata const &);
 }
 
-struct icarus::ICARUSTriggerInfo
-{
-  int version;
-  std::string name;
-  long event_no;
-  long seconds;
-  long nanoseconds;
-  std::string wr_name;
-  long wr_event_no;
-  long wr_seconds;
-  long wr_nanoseconds;
-  int enable_type;
-  long enable_seconds;
-  long enable_nanoseconds;
-  long gate_id;
-  long gate_id_BNB;
-  long gate_id_NuMI;
-  long gate_id_BNBOff;
-  long gate_id_NuMIOff;
-  int gate_type;
-  long beam_seconds;
-  long beam_nanoseconds;
-  int trigger_type;
-  int trigger_source;
-  std::string cryo1_e_conn_0;
-  std::string cryo1_e_conn_2;
-  std::string cryo2_w_conn_0;
-  std::string cryo2_w_conn_2;
-  long cryo1_east_counts;
-  long cryo2_west_counts;
-
-  ICARUSTriggerInfo() {
-    version = 0;
-    name = ""; 
-    event_no = -1; 
-    seconds = -2; 
-    nanoseconds = -3; 
-    wr_name = ""; 
-    wr_event_no = -1; 
-    wr_seconds = -2; 
-    wr_nanoseconds = -3;
-    enable_type = -1;
-    enable_seconds = 0;
-    enable_nanoseconds = 0;
-    gate_id = -4;
-    gate_type = 0;
-    gate_id_BNB = -4;
-    gate_id_NuMI = -4;
-    gate_id_BNBOff = -4;
-    gate_id_NuMIOff = -4;
-    beam_seconds = 0;
-    beam_nanoseconds = 0;
-    trigger_type = 0;
-    trigger_source = 0;
-    cryo1_e_conn_0 = "";
-    cryo1_e_conn_2 = "";
-    cryo2_w_conn_0 = "";
-    cryo2_w_conn_2 = "";
-    cryo1_east_counts = -1;
-    cryo2_west_counts = -1;
-    
-  }
-  uint64_t getNanoseconds_since_UTC_epoch() {
-    if(wr_seconds == -2 || wr_nanoseconds == -3)
-      return 0;
-    int correction = 0;
-    if(wr_seconds >= 1483228800)
-      correction = 37;
-    uint64_t const corrected_ts
-      { (wr_seconds-correction)*1000000000ULL + wr_nanoseconds };
-    return corrected_ts;
-  }
-  
-};
-
-icarus::ICARUSTriggerInfo icarus::parse_ICARUSTriggerV2String(const char* buffer)
+inline icarus::ICARUSTriggerInfo icarus::parse_ICARUSTriggerV2String(const char* buffer)
 {
   std::string data_input = buffer;
   size_t pos = 0;


### PR DESCRIPTION

### Description

Online version of https://github.com/SBNSoftware/sbndaq-artdaq-core/pull/58. See detailed description there. This is designed to correct a strange, rare condition in the trigger decoding due to the definition of the same struct (but one with different data products) in two different places. This PR fixes it. Has been tested in the offline, needs testing online. 

### Testing details
Needs testing and to make sure that offline data decoding and processing works as expected from at least raw->stage0 BEFORE this is made the standard running area for more than a test of this PR or associated release

Reviewers are mostly designated for their own information that this exists in order to test in latest release candidate
