### PR TITLE
TRACE message bugfix

### DIFF
--- a/sbndaq-artdaq-core/Overlays/FragmentType.cc
+++ b/sbndaq-artdaq-core/Overlays/FragmentType.cc
@@ -63,7 +63,7 @@ std::map<artdaq::Fragment::type_t, std::string> sbndaq::makeFragmentTypeMap() {
   }
 
   for (auto name : output) {
-    TLOG(TLVL_DEBUG) << "Verifying map: " << name.first << " --> " << name.second;
+    TLOG(TLVL_DEBUG) << "Verifying map: " << (int)(name.first) << " --> " << name.second;
   }
 
   return output;


### PR DESCRIPTION
### Description

Allows numbers to be correctly displayed in TRACE messages starting with "Verifying map" in /daq/log/pmt/launch_attempt_icarus-evb*

### Testing details
NOT tested! Cosmetic, not urgent change, to be tested alongside some more substantial changes.