### PR TITLE
Feature/rh bottom crt

### DIFF
--- a/sbndaq-artdaq-core/Overlays/FragmentType.cc
+++ b/sbndaq-artdaq-core/Overlays/FragmentType.cc
@@ -22,6 +22,7 @@ static std::map<sbndaq::detail::FragmentType, std::string> const names{
     {sbndaq::detail::FragmentType::WhiteRabbit, "WhiteRabbit"},
 
     // ICARUS
+    {sbndaq::detail::FragmentType::BottomCRT, "BottomCRT"},
     {sbndaq::detail::FragmentType::PHYSCRATEDATA, "PHYSCRATEDATA"},
     {sbndaq::detail::FragmentType::PHYSCRATESTAT, "PHYSCRATESTAT"},
     {sbndaq::detail::FragmentType::ICARUSTriggerUDP, "ICARUSTriggerUDP"},

--- a/sbndaq-artdaq-core/Overlays/FragmentType.hh
+++ b/sbndaq-artdaq-core/Overlays/FragmentType.hh
@@ -22,6 +22,7 @@ enum FragmentType : artdaq::Fragment::type_t {
   WhiteRabbit = artdaq::Fragment::FirstUserFragmentType + 12,
 
   // ICARUS
+  BottomCRT = artdaq::Fragment::FirstUserFragmentType + 18,
   PHYSCRATEDATA = artdaq::Fragment::FirstUserFragmentType + 4,
   PHYSCRATESTAT = artdaq::Fragment::FirstUserFragmentType + 5,
   ICARUSTriggerUDP = artdaq::Fragment::FirstUserFragmentType + 10,
@@ -38,7 +39,7 @@ enum FragmentType : artdaq::Fragment::type_t {
   // Simulators
   DummyGenerator = artdaq::Fragment::FirstUserFragmentType + 8,
 
-  INVALID = artdaq::Fragment::FirstUserFragmentType + 18  // Should always be last.
+  INVALID = artdaq::Fragment::FirstUserFragmentType + 19  // Should always be last.
 };
 
 // Safety check.


### PR DESCRIPTION
### Description

Reserved 18 as a fragment type enum for the Bottom CRT and added a BottomCRT fragment type.

### Related Repository Branches

feature/rh_bottomCRT in sbndaq_artdaq; not necessary for this PR though.

### Testing details
- Compiled and run without error with artdriver
- No run associated with this test, just reserving a fragment type number.