### PR TITLE
Added Nevis Trigger Board fragments, data format and fragment type

### DIFF
--- a/sbndaq-artdaq-core/Overlays/FragmentType.cc
+++ b/sbndaq-artdaq-core/Overlays/FragmentType.cc
@@ -32,6 +32,7 @@ static std::map<sbndaq::detail::FragmentType, std::string> const names{
 
     // SBND
     {sbndaq::detail::FragmentType::NevisTPC, "NEVISTPC"},
+      {sbndaq::detail::FragmentType::NevisTB, "NEVISTB"},
     {sbndaq::detail::FragmentType::PTB, "PTB"},
     {sbndaq::detail::FragmentType::DAPHNE, "DAPHNE"},
     {sbndaq::detail::FragmentType::TDCTIMESTAMP, "TDCTIMESTAMP"},

--- a/sbndaq-artdaq-core/Overlays/FragmentType.hh
+++ b/sbndaq-artdaq-core/Overlays/FragmentType.hh
@@ -32,6 +32,7 @@ enum FragmentType : artdaq::Fragment::type_t {
 
   // SBND
   NevisTPC = artdaq::Fragment::FirstUserFragmentType + 6,
+  NevisTB = artdaq::Fragment::FirstUserFragmentType + 19,
   PTB = artdaq::Fragment::FirstUserFragmentType + 7,
   DAPHNE = artdaq::Fragment::FirstUserFragmentType + 14,
   TDCTIMESTAMP = artdaq::Fragment::FirstUserFragmentType + 16,
@@ -39,7 +40,7 @@ enum FragmentType : artdaq::Fragment::type_t {
   // Simulators
   DummyGenerator = artdaq::Fragment::FirstUserFragmentType + 8,
 
-  INVALID = artdaq::Fragment::FirstUserFragmentType + 19  // Should always be last.
+  INVALID = artdaq::Fragment::FirstUserFragmentType + 20  // Should always be last.
 };
 
 // Safety check.

--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.cc
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.cc
@@ -1,0 +1,1 @@
+#include "sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.hh"

--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.hh
@@ -1,0 +1,105 @@
+#ifndef sbndaq_Overlays_SBND_NevisTBFragment_hh
+#define sbndaq_Overlays_SBND_NevisTBFragment_hh
+
+
+#include "artdaq-core/Data/Fragment.hh"
+#include "sbndaq-artdaq-core/Overlays/SBND/NevisTB_dataFormat.hh"
+#include "sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCTypes.hh"
+#include "sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.hh"
+#include "cetlib_except/exception.h"
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+
+//#pragma GCC diagnostic push                                                                                                                                                                 
+//#pragma GCC diagnostic ignored "-Wpedantic"                                                                                                                                                 
+
+namespace sbndaq {
+  class NevisTBFragmentMetadata;
+  std::ostream & operator << (std::ostream &, NevisTBFragmentMetadata const &);
+
+  class NevisTBFragment;
+  std::ostream & operator << (std::ostream &, NevisTBFragment const &);
+
+}
+
+class sbndaq::NevisTBFragmentMetadata {
+
+private:
+  uint32_t _event_number;
+  uint32_t _frame_number;
+  uint16_t _sample_number;
+  //bool     _is_compressed;
+
+public:
+  NevisTBFragmentMetadata(){}
+  NevisTBFragmentMetadata(uint32_t en, uint32_t fn, uint16_t sn){ // , uint32_t n_samples, bool compressed){
+    _event_number = en;
+    _frame_number = fn;
+    _sample_number = sn;
+    //    _samples_per_channel = n_samples;
+    // _is_compressed = compressed;
+  }
+
+  uint32_t const& EventNumber()const { return _event_number; }
+  uint32_t const& FrameNumber()const { return _frame_number; }
+  uint16_t const& SampleNumber()   const { return _sample_number; }
+  //bool     const& IsCompressed()        const { return _is_compressed; }
+
+  void SetEventNumber(uint32_t en) { _event_number = en; }
+  void SetFrameNumber(uint32_t fn) { _frame_number = fn; }
+  void SetSampleNumber(uint16_t sn) { _sample_number= sn; }
+  //void SetIsCompressed(bool c) { _is_compressed = c; }
+
+  size_t ExpectedDataSize() const {
+    //    return (sizeof(NevisTrigger_Header)+(sizeof(NevisTrigger_Trailer)*_samples_per_channel*_n_channels)+sizeof(NevisTrigger_Trailer));
+    return (sizeof(NevisTrigger_Header)+sizeof(NevisTrigger_Data)+sizeof(NevisTrigger_Trailer));
+  }
+};
+
+
+class sbndaq::NevisTBFragment {
+
+public:
+  NevisTBFragment(artdaq::Fragment const & f) :
+    artdaq_Fragment_(f)
+  {}
+
+  NevisTBFragmentMetadata const * metadata() const
+  { return artdaq_Fragment_.metadata<NevisTBFragmentMetadata>(); }
+
+  NevisTrigger_Header const * header() const
+  { return reinterpret_cast<NevisTrigger_Header const*>(artdaq_Fragment_.dataBeginBytes()); }
+
+  NevisTrigger_Data const * data() const
+  { return reinterpret_cast<NevisTrigger_Data const*>(artdaq_Fragment_.dataBeginBytes()); }
+
+  NevisTrigger_Trailer const * trailer() const
+  { return reinterpret_cast<NevisTrigger_Trailer const*>(artdaq_Fragment_.dataBeginBytes()); }
+
+
+  //  NevisTB_word_t const * data() const
+  //{ return reinterpret_cast<uint16_t const*>(artdaq_Fragment_.dataBeginBytes()+sizeof(NevisTrigger_Header)+sizeof(NevisTrigger_Data)+sizeof(NevisTrigger_Trailer)); }
+
+  size_t ExpectedDataSize() const
+  { return metadata()->ExpectedDataSize(); }
+
+  /*  size_t decode_data(std::unordered_map< uint16_t,NevisTB_Data_t >& wvfm_map) const
+  {
+    NevisTPCDecoder decoder(metadata()->SamplesPerChannel());
+    return decoder.decode_data(data(),header()->getWordCount(),wvfm_map);
+    }*/
+
+  bool Verify() const;
+
+private:
+  artdaq::Fragment const & artdaq_Fragment_;
+};
+
+
+#endif
+

--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTB_dataFormat.cc
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTB_dataFormat.cc
@@ -1,0 +1,58 @@
+#include "NevisTBFragment.hh"
+
+using namespace sbndaq;
+
+std::string NevisTrigger_Header::debugInfo() const noexcept
+{
+  std::ostringstream os;
+
+  os << " Busy[ " << getBusyFlag() << " ],"
+     << " 2MHzSample[ " << get2MHzSampleNumber() << " ],"
+     << " 16MHzRemainder[ " << get16MHzRemainderNumber() << " ],"
+     << " RAW[0x" << trig_time << "]" << std::endl;
+
+  os << " Frame[ " << getFrame() << " ],"
+     << " TriggerNumber[ " << getTriggerNumber() << " ],"
+     << " RAW[0x" << frame_1 << " 0x" << frame_2_and_ntrig_1 << " 0x" << ntrig_2 << "]"
+     << std::endl;
+
+  return os.str();
+}
+
+size_t NevisTrigger_Header::getWordCount() const noexcept
+{
+  return ( sizeof(sbndaq::NevisTrigger_Data) / sizeof(uint32_t) ); //raw_data_type) );                                                                                                        
+}
+
+std::string NevisTrigger_Data::debugInfo() const noexcept
+{
+  std::ostringstream os;
+
+  //  os << "Object " << demangle(typeid(this)) << "."<< std::endl;
+  os << std::hex << std::setfill('0') << std::setw(8);
+  os << " RAW1[0x" << trig_data_1 << "], RAW2[0x" << trig_data_2 << "]" << std::endl;
+  os << "   PMT[0x" << getPMTTrigData() << "]" << std::endl;
+  os << "       PC[ " << Trig_PC() << " ]" << std::endl;
+  os << "      EXT[ " << Trig_EXT() << " ]" << std::endl;
+  os << "    CALIB[ " << Trig_Calib() << " ]" << std::endl;
+  os << "   Active[ " << Trig_Active() << " ]" << std::endl;
+  os << "     VETO[ " << Trig_Veto() << " ]" << std::endl;
+  os << "    GATE1[ " << Trig_Gate1() << " ]" << std::endl;
+  os << "    GATE2[ " << Trig_Gate2() << " ]" << std::endl;
+  os << " GATEFAKE[ " << Trig_GateFake() << " ]" << std::endl;
+  os << " BEAMFAKE[ " << Trig_BeamFake() << " ]" << std::endl;
+  os << "    SPARE[ " << Trig_Spare1() << " ]" << std::endl;
+  os << "    Phase[0x" << getPhase() << "]" << std::endl;
+
+  return os.str();
+}
+
+std::string NevisTrigger_Trailer::debugInfo() const noexcept
+{
+  std::ostringstream os;
+  //  os << "Object " << demangle(typeid(this)) << "."<< std::endl;
+  os << std::hex << std::setfill('0') << std::setw(8);
+
+  os << " Trailer1[0x" << trailer1 << "], Trailer2[0x" << trailer2 << "]" << std::endl;
+  return os.str();
+}

--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTB_dataFormat.hh
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTB_dataFormat.hh
@@ -1,0 +1,212 @@
+#ifndef sbndaq_Overlays_SBND_NevisTB_dataFormat_hh
+#define sbndaq_Overlays_SBND_NevisTB_dataFormat_hh
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+namespace sbndaq {
+
+  struct NevisTrigger_Header;
+  struct NevisTrigger_Data;
+  struct NevisTrigger_Trailer;
+
+
+  //  enum class NevisTBWordType_t;
+
+  //typedef uint16_t                     NevisTB_word_t;
+  //typedef std::vector<NevisTB_word_t>  NevisTB_Data_t;
+
+}
+
+/** Trigger Header Words.                                                                                                                                                                     
+    4 16-bit words.                                                                                                                                                                           
+    (1) 2 MHz Sample number and 16 MHz Remainder                                                                                                                                              
+    (2) Frame number low bits                                                                                                                                                                 
+    (3) Trigger number low bits and frame number high bits                                                                                                                                    
+    (4) Trigger number low bits                                                                                                                                                               
+**/
+
+struct sbndaq::NevisTrigger_Header final
+{
+
+  //first word                                                                                                                                                                                
+  union{
+    struct{
+      uint16_t busy      :1;
+      uint16_t remainder :3;
+      uint16_t sample    :12;
+    };
+    uint16_t trig_time=0xDEAD;
+  } ;
+  bool getBusyFlag() const noexcept{
+    return busy;
+  }
+  uint16_t getSampleNumber() const noexcept{
+    return sample;
+  }
+  uint16_t get2MHzSampleNumber() const noexcept{
+    return sample;
+  }
+  uint16_t get16MHzRemainderNumber() const noexcept{
+    return remainder;
+  }
+
+  //second word                                                                                                                                                                               
+  union {
+    struct {
+      uint16_t frame1 :16;
+    } ;
+    uint16_t frame_1=0xDEAD;
+  } ;
+
+  //third word                                                                                                                                                                                
+  union {
+    struct {
+      uint16_t frame2  :8;
+      uint16_t ntrig1  :8;
+    } ;
+    uint16_t frame_2_and_ntrig_1=0xDEAD;
+  } ;
+  uint32_t getFrame() const noexcept{
+    return frame1+(frame2<<16);
+  }
+
+
+  //fourth word                                                                                                                                                                               
+  union {
+    struct {
+      uint16_t ntrig2  :16;
+    } ;
+    uint16_t ntrig_2=0xDEAD;
+  } ;
+  uint32_t getTriggerNumber() const noexcept{
+    return ntrig1+(ntrig2<<8);
+  }
+
+  std::string debugInfo()const noexcept;
+  size_t      getWordCount() const noexcept;
+  size_t      getModule() const noexcept { return 0; };
+
+};
+
+//static_assert (sizeof(sbndaq::Trigger_Header) == 8, "SBND Trigger_Header structure size is not correct.");                                                                                  
+
+
+/** Trigger Data Words.                                                                                                                                                                       
+    2 16-bit words.                                                                                                                                                                           
+    (1) Trigger bit mask 1                                                                                                                                                                    
+    (2) Trigger bit mask 2                                                                                                                                                                    
+**/
+
+struct sbndaq::NevisTrigger_Data final
+{
+  //first word                                                                                                                                                                                
+  union {
+    struct {
+      uint16_t pmt_trig_data :8;
+      uint16_t pc            :1;
+      uint16_t external      :1;
+      uint16_t active        :1;
+      uint16_t gate2         :1;
+      uint16_t gate1         :1;
+      uint16_t veto          :1;
+      uint16_t calib         :1;
+      uint16_t phase0        :1;
+    } ;
+    uint16_t trig_data_1=0x0;
+  } ;
+  uint8_t getPMTTrigData() const noexcept{
+    return pmt_trig_data;
+  }
+  bool Trig_PMTBeam() const noexcept{
+    return ( (pmt_trig_data&0x01) == 0x01);
+  }
+  bool Trig_PMTCosmic() const noexcept{
+    return ( (pmt_trig_data&0x02) == 0x02);
+  }
+  bool Trig_PC() const noexcept{
+    return pc;
+  }
+  bool Trig_EXT() const noexcept{
+    return external;
+  }
+  bool Trig_Active() const noexcept{
+    return active;
+  }
+  bool Trig_Gate2() const noexcept{
+    return gate2;
+  }
+  bool Trig_Gate1() const noexcept{
+    return gate1;
+  }
+  bool Trig_Veto() const noexcept{
+    return veto;
+  }
+  bool Trig_Calib() const noexcept{
+    return calib;
+  }
+  //second word                                                                                                                                                                               
+  union {
+    struct {
+      uint16_t phase1        :1;
+      uint16_t gatefake      :1;
+      uint16_t beamfake      :1;
+      uint16_t spare1        :1;
+    uint16_t               :12;
+    } ;
+    uint16_t trig_data_2=0xFFF0;
+  } ;
+  uint8_t getPhase() const noexcept{
+    return phase0+(phase1<<1);
+  }
+  bool Trig_GateFake() const noexcept{
+    return gatefake;
+  }
+  bool Trig_BeamFake() const noexcept{
+    return beamfake;
+  }
+  bool Trig_Spare1() const noexcept{
+    return spare1;
+  }
+  std::string debugInfo()const noexcept;
+} ;
+
+struct sbndaq::NevisTrigger_Trailer final
+{
+  //first word                                                                                                                                                                                
+  union {
+    struct {
+      uint16_t marker1    :16;
+    } ;
+    uint16_t trailer1=0xDEAD;
+  } ;
+  uint16_t getMarker1() const noexcept{
+    return marker1;
+  }
+  //second word                                                                                                                                                                               
+  union {
+    struct {
+      uint16_t marker2    :16;
+    } ;
+    uint16_t trailer2=0xDEAD;
+  } ;
+  uint16_t getMarker2() const noexcept{
+    return marker2;
+  }
+  uint32_t getTrailerWord() const noexcept{
+    return (trailer1 + (trailer2<<16));
+  }
+  std::string debugInfo()const noexcept;
+} ;
+
+#pragma GCC diagnostic pop
+
+#endif /* sbndaq_datatypes_Overlays_SBND_NevisTBFragment_hh*/
+
+


### PR DESCRIPTION
### Description
Summary of changes in sbndaq-artdaq-core
(1) Added new overlay classes (NevisTBFragment.hh, NevisTBFragment.cc, NevisTB_dataFormat.hh, NevisTB_dataFormat.cc) to define  Nevis Trigger Board (NTB) fragments and data format
(2) Added a new fragment type for NTB named NevisTB in FragmentType.hh

### Related Repository Branches
The changes made in sbndaq-artdaq-core are tested together with the changes made in sbndaq and sbndaq-artdaq repositories, the links to which are given below-
https://github.com/SBNSoftware/sbndaq-artdaq/compare/develop...feature/kalra_TPC_NTB_implementation
https://github.com/SBNSoftware/sbndaq/compare/develop...feature/kalra_TPC_NTB_implementation

### Testing details
The changes are tested running DAQ on sbnd-evb01, partition 9
- *Where it was tested*: (e.g. SBN-FD, SBN-ND, DAB, etc.)
- Run number - 6871 (/scratch/data/daisy/)

