### PR TITLE
CAENV1730 Metadata Update

### DIFF
--- a/sbndaq-artdaq-core/Overlays/Common/CAENV1730Fragment.cc
+++ b/sbndaq-artdaq-core/Overlays/Common/CAENV1730Fragment.cc
@@ -3,7 +3,7 @@
 
 bool sbndaq::CAENV1730Fragment::Verify() const {
 
-  if(Metadata()->nChannels!=CAEN_V1730_MAX_CHANNELS) 
+  if(Metadata()->nChannels()!=CAEN_V1730_MAX_CHANNELS) 
     return false;
 
   if(ExpectedDataSize() != DataPayloadSize())


### PR DESCRIPTION
### Description

Update CAENV1730 Fragment Metadata:
- Add Post Percent information to CAENV1730 Fragment Metadata
- Backward Compatibility
- Memory efficient → Only return pointer in the overlay class

Update on some analysis modules to handle new CAENV1730 Metadata format

### Related Repository Branches
[sbndaq-artdaq#125](https://github.com/SBNSoftware/sbndaq-artdaq/pull/125)

### Testing details
_(Note: edit as appropriate.)_
- *Where it was tested*: SBN-ND
- *Run number associated with test*: run 9405, 9676, 9677 on sbnd-evb03 
- Other information: Details of test is described in [SBN-doc-33612](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=33612)
