### PR TITLE
Feature/lynnt Update pmtsofttrigger object

### DIFF
--- a/sbndaq-artdaq-core/Obj/SBND/CMakeLists.txt
+++ b/sbndaq-artdaq-core/Obj/SBND/CMakeLists.txt
@@ -4,6 +4,7 @@ cet_make_library(
   SOURCE
     testStandTrigger.cc
     CRTmetric.cc
+    pmtSoftwareTrigger.cc
   LIBRARIES
     ${LIBRARY_CORE_LIB_LIST}
 )

--- a/sbndaq-artdaq-core/Obj/SBND/CRTmetric.hh
+++ b/sbndaq-artdaq-core/Obj/SBND/CRTmetric.hh
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <vector>
+#include <cstdint>
 
 // do we need some initialization here??
 

--- a/sbndaq-artdaq-core/Obj/SBND/CRTmetric.hh
+++ b/sbndaq-artdaq-core/Obj/SBND/CRTmetric.hh
@@ -11,6 +11,7 @@ namespace sbndaq {
   struct CRTmetric{
 
     int hitsperplane[7];
+    std::vector<uint32_t> ts1inbeam;
 
     CRTmetric() {}
 

--- a/sbndaq-artdaq-core/Obj/SBND/pmtSoftwareTrigger.hh
+++ b/sbndaq-artdaq-core/Obj/SBND/pmtSoftwareTrigger.hh
@@ -29,9 +29,11 @@ namespace sbnd::trigger {
 
     bool foundBeamTrigger; 
     int nAboveThreshold;
-    int triggerTimestamp;  // relative to beam window start, in ns
+    int trig_ts;  // relative to beam window start, in ns
     double promptPE;       // total PE for the 100 ns following trigger time 
     double prelimPE;       // total PE for the 1 us before trigger time
+    double peakPE;
+    double peaktime;
     std::vector<sbnd::trigger::pmtInfo> pmtInfoVec;
     pmtSoftwareTrigger() {}
   };


### PR DESCRIPTION
### Description

Updating the object to include beam flash metrics and to change attribute `triggerTimestamp` to `trig_ts`, mainly to avoid confusion with CAEN TTT name. 

This is the PR for adding these changes to the DAQ software stack. Offline PR is #104. These two PRs help converge the offline/online versions of the objects. 

### Related Repository Branches
SBNSoftware/sbndaq-artdaq#149

### Testing details
Tested build with online `sbndaq-artdaq` repo with _offline_ files from run11846. The software trigger/beam metrics are not being run online currently. 