### PR TITLE
Changes from Tereza Kroupova needed to decode PTB fragments

### DIFF
--- a/sbndaq-artdaq-core/Overlays/SBND/PTB_content.h
+++ b/sbndaq-artdaq-core/Overlays/SBND/PTB_content.h
@@ -148,12 +148,12 @@ namespace ptb {
       typedef struct ch_status_t {
 
           static size_t const n_bits_timestamp  = 61 ;
-          static size_t const n_bits_beam       =  3 ;
+          static size_t const n_bits_beam       =  4 ;
           static size_t const n_bits_crt        = 14 ;
           static size_t const n_bits_pds        = 10 ;
           static size_t const n_bits_mtca       =  6 ;
-          static size_t const n_bits_nim        =  6 ;
-          static size_t const n_bits_auxpds     = 25 ;
+          static size_t const n_bits_nim        =  5 ;
+          static size_t const n_bits_auxpds     = 25 ;  // levtovers are for the v2495
           static size_t const n_bits_type       = word_t::n_bits_type ;
 
           typedef uint64_t ts_size_t;
@@ -165,10 +165,10 @@ namespace ptb {
           typedef uint64_t auxpds_size_t;
           typedef uint64_t wtype_size_t;
 
-           ////////bits 0-63//////////////
+           ////////bits 0-64//////////////
            ts_size_t     timestamp  : n_bits_timestamp ;
            beam_size_t   beam       : n_bits_beam ;
-           ////////bits 64-125////////////
+           ////////bits 65-125////////////
            crt_size_t    crt        : n_bits_crt ;
            pds_size_t    pds        : n_bits_pds ;
            mtca_size_t   mtca       : n_bits_mtca ;
@@ -182,11 +182,11 @@ namespace ptb {
 
            // aux_functions Not sure why they are needed
            /*
-           uint8_t  get_beam()   {return (beam   & 0x7)      ;}
+           uint8_t  get_beam()   {return (beam   & 0xF)      ;}
            uint16_t get_crt()    {return (crt    & 0x3FFF)   ;}
            uint16_t get_pds()    {return (pds    & 0x3FF)    ;}
            uint8_t  get_mtca()   {return (mtca   & 0x3F)     ;}
-           uint8_t  get_nim()    {return (mtca   & 0x3F)     ;}
+           uint8_t  get_nim()    {return (mtca   & 0x1F)     ;}
            uint32_t get_auxpds() {return (auxpds & 0x1FFFFFF);} //25{1'b1}
            */
            
@@ -244,7 +244,7 @@ namespace ptb {
            typedef uint64_t wtype_size_t;
 
            ts_size_t timestamp;
-           mask_size_t  trigger_word : n_bits_timestamp ;
+           mask_size_t  trigger_word : n_bits_tmask ;
            wtype_size_t word_type    : n_bits_type ;
 
            //static size_t const size_bytes = sizeof( trigger_t );


### PR DESCRIPTION
### Description

This is a redo of PR 94

https://github.com/SBNSoftware/sbndaq-artdaq-core/pull/94

which was clobbered by Harry's PR 99

https://github.com/SBNSoftware/sbndaq-artdaq-core/pull/99

The affected file is Overlays/SBND/PTB_content.h, and the changes were made to align the overlay with information from Tereza Kroupova to match what the SBND PTB actually produces. The old PTB_content.h had a wrong size for the trigger word in the trigger_t struct, making the decoding incorrect. The develop branch has the right version of PTB_content.h, but the offline branch does not -- the PR proposes to align the offline branch with the correct PTB_content.h, which is what PR 94 did.

I tested it with data from 13561. Enclosed are some plots.
![run13561_llt_wordtypes](https://github.com/SBNSoftware/sbndaq-artdaq-core/assets/11527579/e413ab32-fb19-4f0d-9d6d-16e99f31dffb)
![run13561_llt_trigwords](https://github.com/SBNSoftware/sbndaq-artdaq-core/assets/11527579/b94d8605-02a0-4e51-b08a-5f3aae632545)
![run13561_llt_timestamps](https://github.com/SBNSoftware/sbndaq-artdaq-core/assets/11527579/cd88edf5-e88c-4d2f-8ee7-b914f94d2123)
![run13561_hlt_trgwords](https://github.com/SBNSoftware/sbndaq-artdaq-core/assets/11527579/a196c1a3-2779-4ba1-a4b5-77217ed145d7)
![run13561_hlt_wordtypes](https://github.com/SBNSoftware/sbndaq-artdaq-core/assets/11527579/f483ab8f-d1a2-479f-aaea-ede21e42fda6)
![run13561_hlt_timestamps](https://github.com/SBNSoftware/sbndaq-artdaq-core/assets/11527579/a0223923-a08e-43be-aa9d-fc6ce8a931ff)
