### PR TITLE
add offsets to the data and trailer accessors so they don't all point to the header

### DIFF
--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.hh
@@ -76,10 +76,13 @@ public:
   { return reinterpret_cast<NevisTrigger_Header const*>(artdaq_Fragment_.dataBeginBytes()); }
 
   NevisTrigger_Data const * data() const
-  { return reinterpret_cast<NevisTrigger_Data const*>(artdaq_Fragment_.dataBeginBytes()); }
+  { return reinterpret_cast<NevisTrigger_Data const*>(artdaq_Fragment_.dataBeginBytes()
+                                                      + sizeof(NevisTrigger_Header)); }
 
   NevisTrigger_Trailer const * trailer() const
-  { return reinterpret_cast<NevisTrigger_Trailer const*>(artdaq_Fragment_.dataBeginBytes()); }
+  { return reinterpret_cast<NevisTrigger_Trailer const*>(artdaq_Fragment_.dataBeginBytes()
+                                                         + sizeof(NevisTrigger_Header)
+                                                         + sizeof(NevisTrigger_Data) ); }
 
 
   //  NevisTB_word_t const * data() const


### PR DESCRIPTION
This is a copy of the second commit of 

https://github.com/SBNSoftware/sbndaq-artdaq-core/pull/108

It is designed to propagate the bugfix to develop, and not just the offline branch of this repository.  There is a validation plot in that PR.