### PR TITLE
Fixed SPEC-TDC timestamp rounding error

### DIFF
--- a/sbndaq-artdaq-core/Overlays/SBND/TDCTimestampFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/SBND/TDCTimestampFragment.hh
@@ -49,18 +49,28 @@ struct TDCTimestamp {
 
   // Provides a nano-second approximation of the timestamp.
   uint64_t nanoseconds() const {
-    uint64_t ns = 0;
-    ns += vals.coarse * 8;
-    ns += vals.frac * 8 / 4096;
+    uint64_t ns = 0.0;
+    ns += vals.coarse * 8.0;
+    ns += std::round(vals.frac * 8.0 / 4096.0); //need to round up correctly
     return ns;
   }
 
+  // Provides full UTC timestamp format in nano-second, needed for event building
   uint64_t timestamp_ns() const {
-    uint64_t ns = 0;
-    ns += vals.seconds * 1000000000;
+    uint64_t ns = 0.0;
+    ns += vals.seconds * 1000000000.0;
     ns += nanoseconds();
     return ns;
   }
+
+  // Provides a pico-second approximation of the timestamp.
+  uint64_t picoseconds() const {
+    uint64_t ps = 0.0;
+    ps += vals.coarse * 8000.0;
+    ps += vals.frac * 8000.0 / 4096.0;
+    return ps;
+  }
+
 };
 
 static_assert(sizeof(TDCTimestamp) == TDCTimestamp::size_words * sizeof(TDCTimestamp::data_t),

--- a/sbndaq-artdaq-core/Overlays/SBND/TDCTimestampFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/SBND/TDCTimestampFragment.hh
@@ -51,7 +51,7 @@ struct TDCTimestamp {
   uint64_t nanoseconds() const {
     uint64_t ns = 0.0;
     ns += vals.coarse * 8.0;
-    ns += std::round(vals.frac * 8.0 / 4096.0); //need to round up correctly
+    ns += uint64_t((vals.frac * 8.0 / 4096.0)+0.5); //for correctly rounding up when converting float to unsigned int
     return ns;
   }
 
@@ -67,7 +67,7 @@ struct TDCTimestamp {
   uint64_t picoseconds() const {
     uint64_t ps = 0.0;
     ps += vals.coarse * 8000.0;
-    ps += vals.frac * 8000.0 / 4096.0;
+    ps += uint64_t((vals.frac * 8000.0 / 4096.0)+0.5); //for correctly rounding up when converting float to unsigned int
     return ps;
   }
 


### PR DESCRIPTION

### Description

fix unsigned integer truncating decimal, now doing correct rounding and added picosecond timestamp


_If the full description is in a PR from a different repo, simply link that here, and delete the rest._

### Related Repository Branches

List related branches from other repos here (links to PRs even better!), if not linked above.

### Testing details
_(Note: edit as appropriate.)_
- *Where it was tested*: (e.g. SBN-FD, SBN-ND, DAB, etc.) SBN-ND
- *Run number associated with test*: 
- Other information: 
