### PR TITLE
add uncorrected frame to fragment metadata

### DIFF
--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.hh
@@ -80,11 +80,13 @@ public:
   { return reinterpret_cast<NevisTrigger_Header const*>(artdaq_Fragment_.dataBeginBytes()); }
 
   NevisTrigger_Data const * data() const
-  { return reinterpret_cast<NevisTrigger_Data const*>(artdaq_Fragment_.dataBeginBytes()); }
+  { return reinterpret_cast<NevisTrigger_Data const*>(artdaq_Fragment_.dataBeginBytes()
+                                                      + sizeof(NevisTrigger_Header)); }
 
   NevisTrigger_Trailer const * trailer() const
-  { return reinterpret_cast<NevisTrigger_Trailer const*>(artdaq_Fragment_.dataBeginBytes()); }
-
+  { return reinterpret_cast<NevisTrigger_Trailer const*>(artdaq_Fragment_.dataBeginBytes()
+                                                         + sizeof(NevisTrigger_Header)
+                                                         + sizeof(NevisTrigger_Data) ); }
 
   //  NevisTB_word_t const * data() const
   //{ return reinterpret_cast<uint16_t const*>(artdaq_Fragment_.dataBeginBytes()+sizeof(NevisTrigger_Header)+sizeof(NevisTrigger_Data)+sizeof(NevisTrigger_Trailer)); }

--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.hh
@@ -33,14 +33,16 @@ private:
   uint32_t _event_number;
   uint32_t _frame_number;
   uint16_t _sample_number;
+  uint32_t _uncorrected_frame_number;
   //bool     _is_compressed;
 
 public:
   NevisTBFragmentMetadata(){}
-  NevisTBFragmentMetadata(uint32_t en, uint32_t fn, uint16_t sn){ // , uint32_t n_samples, bool compressed){
+  NevisTBFragmentMetadata(uint32_t en, uint32_t fn, uint16_t sn, uint32_t ufn){ // , uint32_t n_samples, bool compressed){
     _event_number = en;
     _frame_number = fn;
     _sample_number = sn;
+    _uncorrected_frame_number = ufn;
     //    _samples_per_channel = n_samples;
     // _is_compressed = compressed;
   }
@@ -48,11 +50,13 @@ public:
   uint32_t const& EventNumber()const { return _event_number; }
   uint32_t const& FrameNumber()const { return _frame_number; }
   uint16_t const& SampleNumber()   const { return _sample_number; }
+  uint32_t const& UncorrFrameNumber() const {return _uncorrected_frame_number; }
   //bool     const& IsCompressed()        const { return _is_compressed; }
 
   void SetEventNumber(uint32_t en) { _event_number = en; }
   void SetFrameNumber(uint32_t fn) { _frame_number = fn; }
   void SetSampleNumber(uint16_t sn) { _sample_number= sn; }
+  void SetUncorrFrameNumber(uint32_t ufn) {_uncorrected_frame_number = ufn; }
   //void SetIsCompressed(bool c) { _is_compressed = c; }
 
   size_t ExpectedDataSize() const {
@@ -76,13 +80,10 @@ public:
   { return reinterpret_cast<NevisTrigger_Header const*>(artdaq_Fragment_.dataBeginBytes()); }
 
   NevisTrigger_Data const * data() const
-  { return reinterpret_cast<NevisTrigger_Data const*>(artdaq_Fragment_.dataBeginBytes()
-                                                      + sizeof(NevisTrigger_Header)); }
+  { return reinterpret_cast<NevisTrigger_Data const*>(artdaq_Fragment_.dataBeginBytes()); }
 
   NevisTrigger_Trailer const * trailer() const
-  { return reinterpret_cast<NevisTrigger_Trailer const*>(artdaq_Fragment_.dataBeginBytes()
-                                                         + sizeof(NevisTrigger_Header)
-                                                         + sizeof(NevisTrigger_Data) ); }
+  { return reinterpret_cast<NevisTrigger_Trailer const*>(artdaq_Fragment_.dataBeginBytes()); }
 
 
   //  NevisTB_word_t const * data() const

--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTPCFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTPCFragment.hh
@@ -25,28 +25,36 @@ class sbndaq::NevisTPCFragmentMetadata {
   
 private:
   uint32_t _event_number;
+  uint32_t _frame_number;
   uint32_t _samples_per_channel;
   uint32_t _n_channels;
   bool     _is_compressed;
+  uint32_t _uncorrected_frame_number;
   
 public:
   NevisTPCFragmentMetadata(){}
-  NevisTPCFragmentMetadata(uint32_t en, uint32_t n_ch, uint32_t n_samples, bool compressed){
+  NevisTPCFragmentMetadata(uint32_t en, uint32_t fn, uint32_t n_ch, uint32_t n_samples, bool compressed, uint32_t ufn){
     _event_number = en;
+    _frame_number = fn;
     _n_channels = n_ch;
     _samples_per_channel = n_samples;
     _is_compressed = compressed;
+    _uncorrected_frame_number = ufn;
   }
   
   uint32_t const& EventNumber()		const { return _event_number; }
+  uint32_t const& FrameNumber()         const { return _frame_number; }
   uint32_t const& NChannels()           const { return _n_channels; }
   uint32_t const& SamplesPerChannel()   const { return _samples_per_channel; }
   bool     const& IsCompressed()        const { return _is_compressed; }
+  uint32_t const& UncorrFrameNumber()   const { return _uncorrected_frame_number; }
   
   void SetEventNumber(uint32_t en) { _event_number = en; }
+  void SetFrameNumber(uint32_t fn) { _frame_number = fn; }
   void SetNChannels(uint32_t nc) { _n_channels = nc; }
   void SetSamplesPerChannel(uint32_t ns) { _samples_per_channel = ns; }
   void SetIsCompressed(bool c) { _is_compressed = c; }
+  void SetUncorrFrameNumber(uint32_t ufn) { _uncorrected_frame_number = ufn; }
 
   size_t ExpectedDataSize() const {
     return (sizeof(NevisTPCHeader)+(sizeof(NevisTPC_ADC_t)*_samples_per_channel*_n_channels));


### PR DESCRIPTION
### Description

This PR introduces an extra variable in the NTB and TPC fragment metadata. The variables contain the uncorrected frame number (See related PR in sbndaq_artdaq which introduces a correction to the frame). This PR ensures we retain the information about the frame before correction. 

### Related Repository Branches

sbndaq_artdaq: bug/isafa_NTB_Frame_Rollover

### Testing details
- *Where it was tested*: SBN-ND
- *Run number associated with test*: 17384  
