### PR TITLE
Check the size of the NevisTPC Header + ADC words and see if they fit in the fragment.  Truncate ADC words if fragment is too short to protect against segfaults

### DIFF
--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.cc
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.cc
@@ -55,10 +55,9 @@ size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_p
   std::vector<int> differences; // Vector with Huffman-decoded differences
   differences.reserve(14);
 
+  bool skippingSecondWaveform = false;
   for(size_t i_w=0; i_w<n_words; ++i_w){
     w_ptr = data_ptr+i_w;
-
-    bool skippingSecondWaveform = false;
 
     switch(get_word_type(*w_ptr)){
 

--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.cc
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.cc
@@ -58,16 +58,11 @@ size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_p
   for(size_t i_w=0; i_w<n_words; ++i_w){
     w_ptr = data_ptr+i_w;
 
-    bool skiptoend = false;
+    bool skippingSecondWaveform = false;
 
     switch(get_word_type(*w_ptr)){
 
     case NevisTPCWordType_t::kChannelHeader:
-      if (currentChannel == 63) {
-	TRACE(TWARNING,"Unexpected channel header for channel %u found after last channel",*w_ptr & 0x3F);
-	skiptoend = true;
-	break;
-      }
       currentChannel = (*w_ptr & 0x3F);
       TRACE(TDECODE,"Reading channel %u ...",currentChannel);
 
@@ -75,18 +70,24 @@ size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_p
       currentWaveformPtr = &((emplace_pair.first)->second);
 
       if(!(emplace_pair.second)){
-	TRACE(TWARNING,"Previously found channel %u. Overwriting old data!",currentChannel);
-	currentWaveformPtr->clear();
+	TRACE(TWARNING,"Previously found and decoded channel %u. Skipping additional waveforms for this channel!",currentChannel);
+	skippingSecondWaveform = true;
+	break;
+      }
+      else {
+	skippingSecondWaveform = false;
       }
       currentWaveformPtr->reserve(fReserveWvfmSize);
       
       break;
 
     case NevisTPCWordType_t::kADC:
+      if (skippingSecondWaveform) break;
       currentWaveformPtr->emplace_back( (*w_ptr & 0xFFF) );
       break;
 
     case NevisTPCWordType_t::kADCHuffman: { // Brackets needed to declare variables
+      if (skippingSecondWaveform) break;
       zeros=0;
       differences.clear();
       differences.reserve(14); // Speed up: reserve for the maximum number of differences stored in a Huffman word
@@ -105,12 +106,7 @@ size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_p
 
     }break;
     case NevisTPCWordType_t::kChannelEnding:
-      if (currentChannel == 63) {
-	TRACE(TWARNING,"Unexpected channel trailer for channel %u found after last channel",*w_ptr & 0x3F);
-	skiptoend = true;
-	break;
-      }
-
+      if (skippingSecondWaveform) break;
       if( (*w_ptr & 0x3F) == currentChannel )
 	TRACE(TDECODE,"Finished reading channel %u. %lu ADC samples read.",currentChannel,currentWaveformPtr->size());
       else
@@ -123,9 +119,6 @@ size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_p
 
       break;
     }//endswitch
-
-    if (skiptoend) break;
-
   }//end loop over words
 
   return wvfm_map.size();

--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.cc
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.cc
@@ -58,10 +58,16 @@ size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_p
   for(size_t i_w=0; i_w<n_words; ++i_w){
     w_ptr = data_ptr+i_w;
 
+    bool skiptoend = false;
+
     switch(get_word_type(*w_ptr)){
 
     case NevisTPCWordType_t::kChannelHeader:
-
+      if (currentChannel == 63) {
+	TRACE(TWARNING,"Unexpected channel header for channel %u found after last channel",*w_ptr & 0x3F);
+	skiptoend = true;
+	break;
+      }
       currentChannel = (*w_ptr & 0x3F);
       TRACE(TDECODE,"Reading channel %u ...",currentChannel);
 
@@ -99,6 +105,11 @@ size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_p
 
     }break;
     case NevisTPCWordType_t::kChannelEnding:
+      if (currentChannel == 63) {
+	TRACE(TWARNING,"Unexpected channel trailer for channel %u found after last channel",*w_ptr & 0x3F);
+	skiptoend = true;
+	break;
+      }
 
       if( (*w_ptr & 0x3F) == currentChannel )
 	TRACE(TDECODE,"Finished reading channel %u. %lu ADC samples read.",currentChannel,currentWaveformPtr->size());
@@ -113,6 +124,7 @@ size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_p
       break;
     }//endswitch
 
+    if (skiptoend) break;
 
   }//end loop over words
 

--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTPCFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTPCFragment.hh
@@ -40,7 +40,7 @@ public:
     _is_compressed = compressed;
   }
   
-  uint32_t const& EventNumber()		const { return _event_number; }
+  uint32_t const& EventNumber()         const { return _event_number; }
   uint32_t const& FrameNumber()         const { return _frame_number; }
   uint32_t const& NChannels()           const { return _n_channels; }
   uint32_t const& SamplesPerChannel()   const { return _samples_per_channel; }
@@ -79,7 +79,16 @@ public:
   size_t decode_data(std::unordered_map< uint16_t,NevisTPC_Data_t >& wvfm_map) const
   { 
     NevisTPCDecoder decoder(metadata()->SamplesPerChannel());
-    return decoder.decode_data(data(),header()->getADCWordCount(),wvfm_map);
+    auto wc = header()->getADCWordCount();
+    if (sizeof(NevisTPCHeader) + header()->getADCWordCount()*2 > artdaq_Fragment_.dataSizeBytes()) {
+      if (artdaq_Fragment_.dataSizeBytes() > sizeof(NevisTPCHeader)) {
+        wc = (artdaq_Fragment_.dataSizeBytes() - sizeof(NevisTPCHeader))/2;
+      }
+      else {
+        wc = 0;
+      }
+    }
+    return decoder.decode_data(data(),wc,wvfm_map);
   }
 
   bool Verify() const;

--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTPCFragment.hh
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTPCFragment.hh
@@ -80,9 +80,9 @@ public:
   { 
     NevisTPCDecoder decoder(metadata()->SamplesPerChannel());
     auto wc = header()->getADCWordCount();
-    if (sizeof(NevisTPCHeader) + header()->getADCWordCount()*2 > artdaq_Fragment_.dataSizeBytes()) {
+    if (sizeof(NevisTPCHeader) + header()->getADCWordCount()*sizeof(NevisTPC_ADC_t) > artdaq_Fragment_.dataSizeBytes()) {
       if (artdaq_Fragment_.dataSizeBytes() > sizeof(NevisTPCHeader)) {
-        wc = (artdaq_Fragment_.dataSizeBytes() - sizeof(NevisTPCHeader))/2;
+        wc = (artdaq_Fragment_.dataSizeBytes() - sizeof(NevisTPCHeader))/sizeof(NevisTPC_ADC_t);
       }
       else {
         wc = 0;


### PR DESCRIPTION
### Description

This PR adds a check on the size of the data in the artdaq fragment that is used by NevisTPCFragment,  comparing it with the size of the NevisTPCHeader and the ADC words (each of which is assumed to be two bytes per word -- a future commit (already committed, that's commit number 2)  will change this to sizeof(NevisTPC_ADC_t)).  If the total size of the data is bigger than the size of the fragment, then the number of ADC words is reduced so as not to run past the end of the fragment when looping over ADC words.

Subtractions are checked not to return negative values, in case of use of unsigned integers.

### Related Repository Branches

No other repository branches are needed.

### Testing details

SBND Run 17722, taken Nov. 17, 2024, shows problems with the decoder utilities in sbndaq_artdaq_core v1_10_3.  In fifty events in one file, valgrind reports four Invalid reads of size 2 in NevisTPCUtilities.cc, and this happens when the expected size exceeds the fragment size.  Memory corruption has knock-on effects.  Gray Putnam noted a segfault in a reco job far downstream of the actual invalid memory access.

Run 17722 reconstructs fine with the fix above, and valigrind returns no Invalid read errors.

I also tested this on a file in run 12007, taken in March 2024, with an older version of the data format.  The NevisTPC fragment metadata got an extra word in new data.  Reading in old data succeeded in decoding, though the initial memory reservation is too small (64 is put in for the number of samples but it's really the channel count).


