### PR TITLE
add bulletproofing for the case that waveform data come before the first channel header word

### DIFF
--- a/sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.cc
+++ b/sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.cc
@@ -36,8 +36,8 @@ sbndaq::NevisTPCHeader sbndaq::NevisTPCDecoder::decode_header(const char* hdr_pt
 }
 
 size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_ptr,
-					     size_t n_words,
-					     std::unordered_map<uint16_t,sbndaq::NevisTPC_Data_t> & wvfm_map)
+                                            size_t n_words,
+                                            std::unordered_map<uint16_t,sbndaq::NevisTPC_Data_t> & wvfm_map)
 {
   //clear out the output map
   wvfm_map.clear();
@@ -45,7 +45,7 @@ size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_p
   //some initialization so we don't do this in the loops
   const NevisTPC_ADC_t* w_ptr;
   uint16_t currentChannel = 0;
-  NevisTPC_Data_t* currentWaveformPtr;
+  NevisTPC_Data_t* currentWaveformPtr = nullptr;
   std::pair< std::unordered_map<uint16_t,NevisTPC_Data_t>::iterator, bool> emplace_pair;
   uint16_t mask;
   size_t i_diff;
@@ -69,54 +69,55 @@ size_t sbndaq::NevisTPCDecoder::decode_data(const sbndaq::NevisTPC_ADC_t* data_p
       currentWaveformPtr = &((emplace_pair.first)->second);
 
       if(!(emplace_pair.second)){
-	TRACE(TWARNING,"Previously found and decoded channel %u. Skipping additional waveforms for this channel!",currentChannel);
-	skippingSecondWaveform = true;
-	break;
+        TRACE(TWARNING,"Previously found and decoded channel %u. Skipping additional waveforms for this channel!",currentChannel);
+        skippingSecondWaveform = true;
+        break;
       }
       else {
-	skippingSecondWaveform = false;
+        skippingSecondWaveform = false;
       }
       currentWaveformPtr->reserve(fReserveWvfmSize);
-      
       break;
 
     case NevisTPCWordType_t::kADC:
       if (skippingSecondWaveform) break;
+      if (!currentWaveformPtr) break;
       currentWaveformPtr->emplace_back( (*w_ptr & 0xFFF) );
       break;
 
     case NevisTPCWordType_t::kADCHuffman: { // Brackets needed to declare variables
       if (skippingSecondWaveform) break;
+      if (!currentWaveformPtr) break;
       zeros=0;
       differences.clear();
       differences.reserve(14); // Speed up: reserve for the maximum number of differences stored in a Huffman word
 
       // Read the lowest 14 bits from left to right
       for(mask = 0x2000; mask > 0x0; mask = (mask>>1)){
-	if( (*w_ptr & mask) == mask ){ // Found 1
-	  differences.emplace_back( decode_huffman(zeros) );
-	  zeros = 0; // Reset counter
-	} else ++zeros;
+        if( (*w_ptr & mask) == mask ){ // Found 1
+          differences.emplace_back( decode_huffman(zeros) );
+          zeros = 0; // Reset counter
+        } else ++zeros;
       }
       // Differences are time-ordered from right to left
       for(i_diff = differences.size(); i_diff > 0; i_diff--){
-	currentWaveformPtr->emplace_back( currentWaveformPtr->back() + differences[i_diff - 1] );
+        currentWaveformPtr->emplace_back( currentWaveformPtr->back() + differences[i_diff - 1] );
       }
+    } break;
 
-    }break;
     case NevisTPCWordType_t::kChannelEnding:
       if (skippingSecondWaveform) break;
+      if (!currentWaveformPtr) break;
       if( (*w_ptr & 0x3F) == currentChannel )
-	TRACE(TDECODE,"Finished reading channel %u. %lu ADC samples read.",currentChannel,currentWaveformPtr->size());
+        TRACE(TDECODE,"Finished reading channel %u. %lu ADC samples read.",currentChannel,currentWaveformPtr->size());
       else
-	TRACE(TERROR,"ERROR: Channel header %u and ending %u do not match.",currentChannel,(*w_ptr & 0x3F));
-
+        TRACE(TERROR,"ERROR: Channel header %u and ending %u do not match.",currentChannel,(*w_ptr & 0x3F));
       break;
 
     case NevisTPCWordType_t::kUnknown:
       TRACE(TDECODE,"Found unknown word %u.",*w_ptr);
-
       break;
+
     }//endswitch
   }//end loop over words
 


### PR DESCRIPTION

### Description

This PR _Fixes #120 _

The method decode_data in NevisTPCUtilities.cc is not guarded against the case where data that are interpreted as ADC data (either with type kADC or kADCHuffman) come before the first kChannelHeader word in a fragment.  Such data are corrupt, as we do not know what channel they correspond to, and the currentWaveformPtr is uninitialized, causing a segfault.  This was spotted trying to decode data from run 18101, taken January 7, 2025.

### Related Repository Branches

No related branches, just this one.

### Testing details

Bug reproduction before this PR:

gdb --args lar -c run_decoders_job.fcl root://fndca1.fnal.gov:1094//pnfs/fnal.gov/usr/sbnd/archive/sbn/sbn_nd/data/raw/unknown/v1_10_04/sbnd_daq_v1_10_04/daq/00/01/81/01/data_EventBuilder1_art1_run18101_1_strmUnknown_20250107T214345.root

Program received signal SIGSEGV, Segmentation fault.
sbndaq::NevisTPCDecoder::decode_data (this=this@entry=0x7ffffffdd0b0, data_ptr=<optimized out>, n_words=n_words@entry=40593, wvfm_map=...)
    at /home/trj/saut/triggerdecoder/sbndc4/srcs/sbndaq_artdaq_core/sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.cc:97
97		currentWaveformPtr->emplace_back( currentWaveformPtr->back() + differences[i_diff - 1] );

Decoding this file succeeds with this PR, but the data do look corrupt from run 18101  Lots of invalid fragment handles, duplicate
channel headers, mismatching headers and trailers, and the event displays look choppy.  But the decoder succeeds.

same story with data_EventBuilder3_art1_run18101_1_strmUnknown_20250107T214346.root

I also tested a normal file to make sure the decoding wasn't broken by this PR:

data_EventBuilder5_art1_run18214_100_strmBNBZeroBias_20250205T145349.root

decoded just fine.

